### PR TITLE
Fix incorrect usage of ETC and ETH wallet variable

### DIFF
--- a/bbt-multiminer-v6.0.bat
+++ b/bbt-multiminer-v6.0.bat
@@ -1,5 +1,5 @@
 @echo off
-setlocal EnableDelayedExpansion 
+setlocal EnableDelayedExpansion
 rem **********************************************************************
 rem *         BBT Multi-Miner Easy Batch File  v6.0 by BBT Carter        *
 rem **********************************************************************
@@ -28,7 +28,7 @@ SET ZCL_WALLET_ADDRESS=%ZCL%
 SET ZEN_WALLET_ADDRESS=%ZEN%
 SET LTC_WALLET_ADDRESS=%LTC%
 SET BTC_WALLET_ADDRESS=%BTC%
-SET BTG_WALLET_ADDRESS=%BTG% 
+SET BTG_WALLET_ADDRESS=%BTG%
 SET PIRL_WALLET_ADDRESS=%PIRL%
 SET ETN_WALLET_ADDRESS=%ENT%
 SET VTC_WALLET_ADDRESS=%VTC%
@@ -290,7 +290,7 @@ pause
 
 :ethereum2
 ECHO AMD and NVIDIA Claymore 11.6 - Eth Only Nanopool.org
-Miners\Claymore_ETH_Miner_v11.6\EthDcrMiner64.exe -epool eth-us-east1.nanopool.org:9999 -ewal %ETC_WALLET_ADDRESS%/%MINER_NAME%/%EMAIL_ADDRESS% -epsw %WORKER_PASSWORD%
+Miners\Claymore_ETH_Miner_v11.6\EthDcrMiner64.exe -epool eth-us-east1.nanopool.org:9999 -ewal %ETH_WALLET_ADDRESS%/%MINER_NAME%/%EMAIL_ADDRESS% -epsw %WORKER_PASSWORD%
 if %ERRORLEVEL% NEQ 0 goto exit
 pause
 
@@ -300,7 +300,7 @@ pause
 
 :ethereumc1
 ECHO AMD and NVIDIA Claymore 11.6 - Etc (ethereum classic) etc.ethermine.org
-Miners\Claymore_ETH_Miner_v11.6\EthDcrMiner64.exe -epool us1-etc.ethermine.org:4444 -ewal %ETH_WALLET_ADDRESS%.%MINER_NAME% -epsw %WORKER_PASSWORD% -mode 1 -allpools 1 
+Miners\Claymore_ETH_Miner_v11.6\EthDcrMiner64.exe -epool us1-etc.ethermine.org:4444 -ewal %ETC_WALLET_ADDRESS%.%MINER_NAME% -epsw %WORKER_PASSWORD% -mode 1 -allpools 1 
 if %ERRORLEVEL% NEQ 0 goto exit
 pause
 


### PR DESCRIPTION
Feel free to close this PR if my assumptions are wrong but I think the ETC_WALLET variable was being used for ethereum and the ETH_WALLET variable was being used for ethereum classic. Looks like there was a copy past error in the initial change. And it looks like I cleaned up some white space at end of lines, hope that is ok.  